### PR TITLE
corrected path to embed config file in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@
         src/app/server/config.ts
     ```typescript
     import HttpEndpoint from '../../common/HttpEndpoint';
-    
+
     let config: {
     	apiServer: HttpEndpoint,
     	chromeExtensionId: string,
@@ -40,7 +40,7 @@
     	stripePublishableKey: string,
     	webServer: HttpEndpoint
 	 };
-	 
+
     config = {
     	apiServer: {
     		protocol: 'https',
@@ -73,7 +73,7 @@
 ### Embed
 1. Configure the embed
 
-        src/embed/config/dev/json
+        src/embed/config.dev.json
     ```json
     {
     	"apiServer": {


### PR DESCRIPTION
Corrected a path in the readme. Some extant trailing whitespace was also removed automatically by the editor respecting the .editorconfig file.
