### PR TITLE
Duplicate NavBar to AppRoot specific-version with removed Blog link. …

### DIFF
--- a/src/app/common/components/AppRoot.tsx
+++ b/src/app/common/components/AppRoot.tsx
@@ -65,7 +65,7 @@ import createReadScreenFactory from './AppRoot/ReadScreen';
 import { AppPlatform, isAppleAppPlatform } from '../../../common/AppPlatform';
 import ShareForm from '../../../common/models/analytics/ShareForm';
 import { ShareChannelData } from '../../../common/sharing/ShareData';
-import NavBar from './BrowserRoot/NavBar';
+import NavBar from './AppRoot/NavBar';
 
 interface Props extends RootProps {
 	appApi: AppApi,

--- a/src/app/common/components/AppRoot/NavBar.scss
+++ b/src/app/common/components/AppRoot/NavBar.scss
@@ -1,0 +1,45 @@
+/*
+        componentPath: src/app/common/components/AppRoot/NavBar
+        cssComponentId: nav-bar_3e49ke
+*/
+@import '../../../../common/styles/colors';
+@import '../../../../common/styles/breakpoints';
+@import '../AppRoot/Header.scss';
+
+.nav-bar_3e49ke {
+	display: none;
+}
+
+@include from(tablet-landscape) {
+	.nav-bar_3e49ke {
+		flex: 0 0 auto;
+		display: flex;
+		flex-flow: column;
+		border-right-width: 1px;
+		border-right-style: solid;
+		padding-top: $header-height;
+	}
+	.nav-bar_3e49ke > ol {
+		flex: 1 1 auto;
+		display: flex;
+		flex-flow: column;
+	}
+	.nav-bar_3e49ke > .footer {
+		flex: 0 0 auto;
+		text-align: center;
+		padding: 20px;
+	}
+
+}
+
+@include theme using ($root, $scheme) {
+	#{$root} .nav-bar_3e49ke {
+		@include theme-colors(
+			$scheme,
+			(
+				"border-right-color": $nav-border-color,
+				"background-color": $nav-background-color
+			)
+		);
+	}
+}

--- a/src/app/common/components/AppRoot/NavBar.tsx
+++ b/src/app/common/components/AppRoot/NavBar.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react';
+import ScreenKey from '../../../../common/routing/ScreenKey';
+import { findRouteByKey } from '../../../../common/routing/Route';
+import routes from '../../../../common/routing/routes';
+import UserAccount, { hasAnyAlerts } from '../../../../common/models/UserAccount';
+import { Screen, NavReference, NavOptions } from '../Root';
+import Button from '../../../../common/components/Button';
+import Alert from '../../../../common/models/notifications/Alert';
+
+const
+	homeUrl = findRouteByKey(routes, ScreenKey.Home).createUrl(),
+	myImpactUrl = findRouteByKey(routes, ScreenKey.MyImpact).createUrl(),
+	myReadsUrl = findRouteByKey(routes, ScreenKey.MyReads).createUrl();
+
+interface Props {
+	onNavTo: (ref: NavReference, options: NavOptions) => void,
+	onViewHome: () => void,
+	onViewMyImpact: () => void,
+	onViewMyReads: () => void,
+	selectedScreen: Screen,
+	user: UserAccount
+}
+export default class NavBar extends React.PureComponent<Props> {
+	public render() {
+		return (
+			<div className="nav-bar_3e49ke">
+				<ol>
+					<li>
+						<Button
+							badge={hasAnyAlerts(this.props.user, Alert.Aotd) ? 1 : 0}
+							href={homeUrl}
+							onClick={this.props.onViewHome}
+							state={this.props.selectedScreen.key === ScreenKey.Home ? 'selected' : 'normal'}
+							iconLeft="earth"
+							text="Discover"
+							size="x-large"
+							display="block"
+						/>
+					</li>
+					<li>
+						<Button
+							href={myReadsUrl}
+							onClick={this.props.onViewMyReads}
+							state={this.props.selectedScreen.key === ScreenKey.MyReads ? 'selected' : 'normal'}
+							iconLeft="star"
+							text="My Reads"
+							size="x-large"
+							display="block"
+						/>
+					</li>
+					<li>
+						<Button
+							href={myImpactUrl}
+							onClick={this.props.onViewMyImpact}
+							state={this.props.selectedScreen.key === ScreenKey.MyImpact ? 'selected' : 'normal'}
+							iconLeft="dollar"
+							text="My Impact"
+							size="x-large"
+							display="block"
+						/>
+					</li>
+				</ol>
+				<div className="footer"></div>
+			</div>
+		);
+	}
+}

--- a/src/app/common/components/BrowserRoot/NavBar.scss
+++ b/src/app/common/components/BrowserRoot/NavBar.scss
@@ -3,33 +3,23 @@
 	cssComponentId: nav-bar_yh8orf
 */
 @import '../../../../common/styles/colors';
-@import '../../../../common/styles/breakpoints';
-@import '../AppRoot/Header.scss';
 
 .nav-bar_yh8orf {
-	display: none;
+	flex: 0 0 auto;
+	display: flex;
+	flex-flow: column;
+	border-right-width: 1px;
+	border-right-style: solid;
 }
-
-@include from(tablet-landscape) {
-	.nav-bar_yh8orf {
-		flex: 0 0 auto;
-		display: flex;
-		flex-flow: column;
-		border-right-width: 1px;
-		border-right-style: solid;
-		padding-top: $header-height;
-	}
-	.nav-bar_yh8orf > ol {
-		flex: 1 1 auto;
-		display: flex;
-		flex-flow: column;
-	}
-	.nav-bar_yh8orf > .footer {
-		flex: 0 0 auto;
-		text-align: center;
-		padding: 20px;
-	}
-
+.nav-bar_yh8orf > ol {
+	flex: 1 1 auto;
+	display: flex;
+	flex-flow: column;
+}
+.nav-bar_yh8orf > .footer {
+	flex: 0 0 auto;
+	text-align: center;
+	padding: 20px;
 }
 
 @include theme using ($root, $scheme) {


### PR DESCRIPTION
- Duplicate NavBar component to AppRoot specific-version with removed Blog link
- Revert BrowserRoot NavBar to original, because existing logged in readers will still be logged in in BrowserRoot. I previously edited the BrowserRoot NavBar to be responsive, and that probably would have looked bad/overlapping at mobile web widths.