### PR TITLE
Fix reference to revenue on homepage (not there anymore)

### DIFF
--- a/src/app/common/components/FaqPage.tsx
+++ b/src/app/common/components/FaqPage.tsx
@@ -160,8 +160,7 @@ const faqs: FaqCategory[] = [
 			},
 			{
 				question: "How much money has Readup earned for writers?",
-				answer: <p>Writer earnings and total Readup revenue are visible on the homepage and at the bottom of the menu. Individual, finalized distributions, broken down by writer, are visible <Link screen={ScreenKey.Leaderboards} onClick={props.onNavTo}>here</Link>.</p>
-			},
+				answer: <p>Writer earnings and total Readup revenue are visible on the bottom of the side menu in the Readup app. Individual, finalized distributions, broken down by writer, are visible <Link screen={ScreenKey.Leaderboards} onClick={props.onNavTo}>here</Link>.</p>			},
 			{
 				question: "What do you do with money earned by deceased writers?",
 				answer: <p>Money earned by dead writers (Ernest Hemingway and Toni Morrison, for example) gets donated to <Link href="https://www.eff.org/" onClick={props.onNavTo}>EFF: Electronic Frontier Foundation</Link>. Readup’s mission aligns with the work that EFF does to defend digital privacy, free speech, and innovation.</p>


### PR DESCRIPTION
Created a draft PR, to remind us that going through the whole FAQ is a good idea!