### PR TITLE
Fix opening reading view when trying to post (adds stopPropagation pr…

### DIFF
--- a/src/common/components/ArticleDetails.tsx
+++ b/src/common/components/ArticleDetails.tsx
@@ -287,6 +287,7 @@ export default class extends React.PureComponent<Props, {
 										article={this.props.article}
 										menuPosition={MenuPosition.LeftMiddle}
 										onPost={this.props.onPost}
+										stopPropagation={true}
 									/>
 								</div> :
 								null}

--- a/src/common/components/ArticleDetailsDisplay.tsx
+++ b/src/common/components/ArticleDetailsDisplay.tsx
@@ -126,6 +126,7 @@ export default class extends ArticleDetails {
 											article={this.props.article}
 											menuPosition={MenuPosition.LeftMiddle}
 											onPost={this.props.onPost}
+											stopPropagation={true}
 										/>
 									</div> :
 									null

--- a/src/common/components/Button.tsx
+++ b/src/common/components/Button.tsx
@@ -22,8 +22,9 @@ interface Props {
 	showIndicator?: boolean,
 	size?: ButtonSize,
 	state?: 'normal' | 'disabled' | 'busy' | 'set' | 'selected',
+	stopPropagation?: boolean,
 	style?: 'normal' | 'preferred',
-	text?: string
+	text?: string,
 }
 export default class Button extends React.PureComponent<Props> {
 	public static defaultProps: Pick<Props, 'align' | 'display' | 'hrefPreventDefault'> = {
@@ -34,6 +35,9 @@ export default class Button extends React.PureComponent<Props> {
 	private readonly _click = (event: React.MouseEvent) => {
 		if (this.props.href && this.props.hrefPreventDefault) {
 			event.preventDefault();
+		}
+		if (this.props.stopPropagation) {
+			event.stopPropagation();
 		}
 		if (
 			this.props.onClick &&

--- a/src/common/components/PostButton.tsx
+++ b/src/common/components/PostButton.tsx
@@ -8,7 +8,8 @@ import Link from './Link';
 interface Props {
 	article: UserArticle,
 	menuPosition: MenuPosition,
-	onPost: (article: UserArticle) => void
+	onPost: (article: UserArticle) => void,
+	stopPropagation?: boolean
 }
 export default class PostButton extends React.PureComponent<
 	Props,
@@ -50,6 +51,8 @@ export default class PostButton extends React.PureComponent<
 							<Link
 								text="Post again"
 								onClick={this._post}
+								// stopPropagation is implied here
+								// https://github.com/reallyreadit/web/blob/500a41c5f9fa588e19b15cd85501f3f17a23366d/src/common/components/Popover.tsx#L54
 							/>
 						</div>
 					}
@@ -58,11 +61,13 @@ export default class PostButton extends React.PureComponent<
 					onBeginClosing={this._beginClosingMenu}
 					onClose={this._closeMenu}
 					onOpen={this._openMenu}
+					stopPropagation={this.props.stopPropagation}
 				>
 					<Button
 						intent="success"
 						state="set"
 						text="Post"
+						stopPropagation={this.props.stopPropagation}
 					/>
 				</Popover>
 			);
@@ -73,6 +78,7 @@ export default class PostButton extends React.PureComponent<
 				intent="success"
 				onClick={this._post}
 				text="Post"
+				stopPropagation={this.props.stopPropagation}
 			/>
 		);
 	}


### PR DESCRIPTION
…ops for PostButton)

See pivotal: https://www.pivotaltracker.com/story/show/180234655/comments/228176011 
> thor
> @th0rgall
> There's an ugly bug that we both missed remaining! You can't Post from ArticleDetails, it opens the reader immediately. I forgot to do stopPropagation there it seems. I'll try to patch it ASAP.