### PR TITLE
Posts 2.0 (ArticleDetails inside PostDetails)

### DIFF
--- a/src/common/components/AbstractCommentShareable.tsx
+++ b/src/common/components/AbstractCommentShareable.tsx
@@ -1,0 +1,76 @@
+import React = require("react");
+import {formatPossessive} from "../format";
+import CommentThread from "../models/CommentThread";
+import Post, {createCommentThread} from "../models/social/Post";
+import UserAccount from "../models/UserAccount";
+import {findRouteByKey} from "../routing/Route";
+import routes from "../routing/routes";
+import ScreenKey from "../routing/ScreenKey";
+
+type AbstractProps = {
+	comment?: CommentThread,
+	post?: Post,
+	onCreateAbsoluteUrl: (path: string) => string,
+	user: UserAccount | null
+}
+
+/**
+ * Superclass to share code for classes that can share a posted comment
+*/
+export default abstract class AbstractCommentShareable<Props extends AbstractProps, State = {}> extends React.Component<Props, State> {
+
+	private readonly _commentsScreenRoute = findRouteByKey(routes, ScreenKey.Comments);
+
+	protected _hasComment = () => {
+		return !!this.props.post.comment;
+	}
+
+	protected _getCommentThread = (): CommentThread | undefined => {
+		if (this.props.post && this.props.post.comment) {
+			return createCommentThread(this.props.post);
+		} else if (this.props.comment) {
+			return this.props.comment
+		}
+		return undefined;
+	}
+
+	protected getCommentAbsoluteUrl() {
+		const [sourceSlug, articleSlug] = this._getCommentThread().articleSlug.split('_');
+		return this.props.onCreateAbsoluteUrl(
+			this._commentsScreenRoute.createUrl({
+				['articleSlug']: articleSlug,
+				['commentId']: this._getCommentThread().id,
+				['sourceSlug']: sourceSlug
+			})
+		);
+	}
+
+	protected readonly _getShareData = () => {
+		const
+			articleTitle = this._getCommentThread().articleTitle,
+			commentAuthor = this._getCommentThread().userAccount,
+			quotedCommentText = this._getCommentThread().text
+				.split(/\n\n+/)
+				.map((paragraph, index, paragraphs) => `"${paragraph}${index === paragraphs.length - 1 ? '"' : ''}`)
+				.join('\n\n'),
+			shareUrl = this.getCommentAbsoluteUrl();
+		return {
+			action: 'Comment',
+			email: {
+				body: `${quotedCommentText}\n\n${shareUrl}`,
+				subject: (
+					this.props.user && this.props.user.name === commentAuthor ?
+						`My comment on "${articleTitle}"` :
+						`Check out ${formatPossessive(commentAuthor)} comment on "${articleTitle}"`
+				)
+			},
+			text: (
+				this.props.user && this.props.user.name === commentAuthor ?
+					this._getCommentThread().text :
+					`Check out ${formatPossessive(commentAuthor)} comment on "${articleTitle}"`
+			),
+			url: shareUrl
+		};
+	};
+
+}

--- a/src/common/components/ArticleDetails.tsx
+++ b/src/common/components/ArticleDetails.tsx
@@ -44,16 +44,19 @@ interface Props {
 	shareMenuPosition?: MenuPosition,
 	showAotdMetadata?: boolean,
 	showDescription?: boolean,
+	// metadata actions: the bottom metadata bar with reads (not an action), comments link, rating control
+	showMetaActions?: boolean,
 	showImage?: boolean,
 	user?: UserAccount
 }
 export default class extends React.PureComponent<Props, {
 		isStarring: boolean,
 	}> {
-	public static defaultProps: Pick<Props, 'shareMenuPosition' | 'showAotdMetadata' | 'showImage'> = {
+	public static defaultProps: Pick<Props, 'shareMenuPosition' | 'showAotdMetadata' | 'showImage' | 'showMetaActions'> = {
 		shareMenuPosition: MenuPosition.LeftTop,
 		showAotdMetadata: true,
-		showImage: false
+		showImage: false,
+		showMetaActions: true
 	};
 	protected readonly _getShareData = () => {
 		return getShareData(
@@ -149,7 +152,8 @@ export default class extends React.PureComponent<Props, {
 						pointsCallout={this.props.pointsCallout}
 						rankCallout={this.props.rankCallout}
 					/> :
-					null}
+					null
+				}
 				<div
 					className="article-container"
 					onClick={this._read}
@@ -206,17 +210,19 @@ export default class extends React.PureComponent<Props, {
 									this.props.showDescription && !!this.props.article.description ?
 										<p className="description">{truncateText(this.props.article.description, this.MAX_DESCRIPTION_LENGTH)}</p> : null
 								}
-								<div className="stats">
-									<span className="reads">{this.props.article.readCount} {formatCountable(this.props.article.readCount, 'read')}</span>
-									<a
-										className="comments"
-										href={this._renderCommentsLinkHref()}
-										onClick={this._viewComments}
-									>
-										{this.props.article.commentCount} {formatCountable(this.props.article.commentCount, 'comment')}
-									</a>
-									{this._renderRatingControl()}
-								</div>
+								{ this.props.showMetaActions ?
+									<div className="stats">
+										<span className="reads">{this.props.article.readCount} {formatCountable(this.props.article.readCount, 'read')}</span>
+										<a
+											className="comments"
+											href={this._renderCommentsLinkHref()}
+											onClick={this._viewComments}
+										>
+											{this.props.article.commentCount} {formatCountable(this.props.article.commentCount, 'comment')}
+										</a>
+										{this._renderRatingControl()}
+									</div> : null
+								}
 							</div>
 							<div className="small-stats-article">
 								<div className="meta">
@@ -249,21 +255,22 @@ export default class extends React.PureComponent<Props, {
 									this.props.showDescription && !!this.props.article.description ?
 										<p className="description">{this.props.article.description}</p> : null
 								}
-								<div className="stats">
-									<div className="reads">
-										<span>{this.props.article.readCount} {formatCountable(this.props.article.readCount, 'read')}</span>
-									</div>
-									<div className="comments">
-										<a
-											href={this._renderCommentsLinkHref()}
-											onClick={this._viewComments}
-										>
-											{this.props.article.commentCount} {formatCountable(this.props.article.commentCount, 'comment')}
-										</a>
-									</div>
-									{this._renderRatingControl()}
-
-								</div>
+								{ this.props.showMetaActions ?
+									<div className="stats">
+										<div className="reads">
+											<span>{this.props.article.readCount} {formatCountable(this.props.article.readCount, 'read')}</span>
+										</div>
+										<div className="comments">
+											<a
+												href={this._renderCommentsLinkHref()}
+												onClick={this._viewComments}
+											>
+												{this.props.article.commentCount} {formatCountable(this.props.article.commentCount, 'comment')}
+											</a>
+										</div>
+										{this._renderRatingControl()}
+									</div>  : null
+								}
 							</div>
 							{(
 								this.props.onPost &&

--- a/src/common/components/PostDetails.scss
+++ b/src/common/components/PostDetails.scss
@@ -8,13 +8,25 @@
 	animation-duration: 2500ms;
 	animation-fill-mode: forwards;
 	animation-delay: 500ms;
+
 }
-.post-details_8qx033 > .content > .post-header_f4a846,
+.post-details_8qx033 > .content-box_kkp9lc.content {
+	border-radius: 0 0 3px 3px;
+	border-top-width: 0;
+    border-color: var(--intent-neutral-color);
+}
+.post-details_8qx033 > .content > .article-details_d2vnmv {
+	padding: 10px;
+    border-width: 1px;
+    border-style: solid;
+    border-radius: 3px;
+    border-color: var(--content-border-color);
+}
 .post-details_8qx033 > .content > .comment-details_qker1u {
 	margin-top: 10px;
 }
-.post-details_8qx033 > .content > .post-header_f4a846 {
-	border-radius: 3px;
+.post-details_8qx033 > .post-header_f4a846 {
+	border-radius: 3px 3px 0 0;
 }
 
 @keyframes post-details_8qx033-alert-light {

--- a/src/common/components/PostDetails.tsx
+++ b/src/common/components/PostDetails.tsx
@@ -11,9 +11,9 @@ import PostHeader from './PostHeader';
 import CommentThread from '../models/CommentThread';
 import classNames from 'classnames';
 import Rating from '../models/Rating';
-import AotdMetadata from './AotdMetadata';
 import {DeviceType} from '../DeviceType';
 import { ShareChannelData } from '../sharing/ShareData';
+import AbstractCommentShareable from './AbstractCommentShareable';
 
 interface Props {
 	deviceType: DeviceType,
@@ -35,15 +35,31 @@ interface Props {
 	post: Post,
 	user: UserAccount | null
 }
-export default class PostDetails extends React.Component<Props> {
+export default class PostDetails extends AbstractCommentShareable<Props> {
+
 	public render() {
+		const commentThread = this._getCommentThread();
 		return (
 			<div className="post-details_8qx033">
-				<AotdMetadata
-					article={this.props.post.article}
-					onCreateAbsoluteUrl={this.props.onCreateAbsoluteUrl}
-					onViewProfile={this.props.onViewProfile}
-				/>
+				{this._hasComment() ?
+					<PostHeader
+						userName={commentThread.userAccount}
+						leaderboardBadge={commentThread.badge}
+						isAuthor={commentThread.isAuthor}
+						date={commentThread.dateCreated}
+						onCreateAbsoluteUrl={this.props.onCreateAbsoluteUrl}
+						onGetShareData={this._getShareData}
+						onShare={this.props.onShare}
+						onShareViaChannel={this.props.onShareViaChannel}
+						onViewProfile={this.props.onViewProfile}
+					/> :
+					<PostHeader
+						userName={this.props.post.userName}
+						leaderboardBadge={this.props.post.badge}
+						date={this.props.post.date}
+						onCreateAbsoluteUrl={this.props.onCreateAbsoluteUrl}
+						onViewProfile={this.props.onViewProfile}
+				/>}
 				<ContentBox
 					className={classNames('content', { 'alert': this.props.post.hasAlert })}
 					highlight={
@@ -60,18 +76,19 @@ export default class PostDetails extends React.Component<Props> {
 						deviceType={this.props.deviceType}
 						onCreateAbsoluteUrl={this.props.onCreateAbsoluteUrl}
 						onNavTo={this.props.onNavTo}
-						onRateArticle={this.props.onRateArticle}
 						onPost={this.props.onPost}
+						onRateArticle={this.props.onRateArticle}
 						onRead={this.props.onRead}
 						onShare={this.props.onShare}
 						onShareViaChannel={this.props.onShareViaChannel}
-						showAotdMetadata={false}
 						onToggleStar={this.props.onToggleStar}
 						onViewComments={this.props.onViewComments}
 						onViewProfile={this.props.onViewProfile}
+						showAotdMetadata={false}
+						showMetaActions={false}
 						user={this.props.user}
 					/>
-					{this.props.post.comment ?
+					{ this._hasComment() ?
 						<CommentDetails
 							comment={createCommentThread(this.props.post)}
 							onCloseDialog={this.props.onCloseDialog}
@@ -83,14 +100,9 @@ export default class PostDetails extends React.Component<Props> {
 							onViewProfile={this.props.onViewProfile}
 							onViewThread={this.props.onViewThread}
 							user={this.props.user}
-						/> :
-						<PostHeader
-							userName={this.props.post.userName}
-							leaderboardBadge={this.props.post.badge}
-							date={this.props.post.date}
-							onCreateAbsoluteUrl={this.props.onCreateAbsoluteUrl}
-							onViewProfile={this.props.onViewProfile}
-						/>}
+							showPostHeader={false}
+						/> : null
+					}
 				</ContentBox>
 			</div>
 		);

--- a/src/common/components/PostHeader.scss
+++ b/src/common/components/PostHeader.scss
@@ -13,11 +13,19 @@
 .post-header_f4a846.has-flair {
 	padding: 3px 10px;
 }
+
+$spacing: 10px;
+// spacing between items
+.post-header_f4a846 > .user-name,
+.post-header_f4a846 > .leaderboard-badges_s4o6nj,
+.post-header_f4a846 > .posted-copy {
+	margin-right: $spacing;
+}
+
 .post-header_f4a846 > .user-name {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	font-family: 'Museo Sans (500)';
-	margin-right: 10px;
 }
 .post-header_f4a846 > .leaderboard-badges_s4o6nj {
 	flex: 0 0 auto;
@@ -29,7 +37,7 @@
 }
 .post-header_f4a846 > .share-control_mnbspk {
 	flex: 0 0 auto;
-	margin-left: 10px;
+	margin-left: $spacing;
 }
 .post-header_f4a846 > .author {
 	display: flex;

--- a/src/common/components/PostHeader.tsx
+++ b/src/common/components/PostHeader.tsx
@@ -11,19 +11,25 @@ import UserAccount from '../models/UserAccount';
 import { ShareEvent } from '../sharing/ShareEvent';
 import * as classNames from 'classnames';
 
-export default (
-	props: {
-		userName: string,
-		leaderboardBadge: LeaderboardBadge,
-		isAuthor?: boolean,
-		date: string
-		onCreateAbsoluteUrl: (path: string) => string,
-		onGetShareData?: () => ShareData,
-		onShare?: (data: ShareEvent) => ShareResponse,
-		onShareViaChannel?: (data: ShareChannelData) => void,
-		onViewProfile: (userName: string) => void,
-		user?: UserAccount
-	}
+interface Props {
+	userName: string,
+	leaderboardBadge: LeaderboardBadge,
+	isAuthor?: boolean,
+	date: string
+	onCreateAbsoluteUrl: (path: string) => string,
+	onGetShareData?: () => ShareData,
+	onShare?: (data: ShareEvent) => ShareResponse,
+	onShareViaChannel?: (data: ShareChannelData) => void,
+	onViewProfile: (userName: string) => void,
+	/** adds the copy "posted" to make explicitly denote the action done
+	 * NOTE: unused for now, part of an update that we may include soon
+	*/
+	verbose?: boolean,
+	user?: UserAccount
+};
+
+const PostHeader = (
+	props: Props
 ) => (
 	<div className={classNames('post-header_f4a846', { 'has-flair': props.isAuthor })}>
 		{!!props.userName && (!props.user || props.user.name !== props.userName) ?
@@ -37,6 +43,9 @@ export default (
 		{props.leaderboardBadge !== LeaderboardBadge.None ?
 			<LeaderboardBadges badge={props.leaderboardBadge} /> :
 			null}
+		{
+			props.verbose ? <span className="posted-copy">posted</span> : null
+		}
 		<span className="age">{format(props.date.replace(/([^Z])$/, '$1Z'))}</span>
 		{(
 			props.userName &&
@@ -64,3 +73,9 @@ export default (
 			null}
 	</div>
 );
+
+PostHeader.defaultProps = {
+	verbose: false
+};
+
+export default PostHeader;

--- a/src/common/components/comments/CommentDetails.scss
+++ b/src/common/components/comments/CommentDetails.scss
@@ -45,24 +45,6 @@
 .comment-details_qker1u > .replies > li {
 	margin-top: 5px;
 }
-.comment-details_qker1u.post-embed {
-	border-width: 1px;
-	border-style: solid;
-	border-radius: 3px;
-	border-top-width: 0;
-}
-.comment-details_qker1u.post-embed > .post-header_f4a846 {
-	border-radius: 3px 3px 0 0;
-}
-.comment-details_qker1u.post-embed > .text-wrapper > .text {
-	margin: 10px;
-}
-.comment-details_qker1u.post-embed > .addenda {
-	padding: 0 10px 10px 10px;
-}
-.comment-details_qker1u.post-embed > .actions {
-	margin: 0 10px 10px 10px;
-}
 
 @media (max-width: 449px) {
 	.comment-details_qker1u > .actions {
@@ -87,14 +69,6 @@
 			$scheme,
 			(
 				"border-left-color": $content-divider-color
-			)
-		);
-	}
-	#{$root} .comment-details_qker1u.post-embed {
-		@include theme-colors(
-			$scheme,
-			(
-				"border-color": $intent-neutral-color
 			)
 		);
 	}


### PR DESCRIPTION
- There were a few ways to include `ArticleDetails` visually _inside_ a comment box. I did not opt for extending `CommentDetails` with a way to embed the `ArticleDetails`, but instead opted for this component structure, because I think it's a bit better in terms of composability:
  ```
  PostDetails
  -> PostHeader (different props depending on silent post/comment post)
  -> ContentBox
    -> ArticleDetails
    -> CommentDetails (optional, absent when silent posting)
  ```

- The `AbstractCommentShareable` class is probably the weirdest thing in this commit, it's an attempt to make the `_getShareData` function and sub-functions reusable so I didn't have to copy-paste it. It includes some potentially sketchy typing (`comment?` and `post?` to make the class extandable by both `PostDetails` and `ArticleDetails`. Maybe copy-pasting was better. Or extracting it into reusable static methods. Or the Typesript Mixin pattern I tried to investigate for a while.